### PR TITLE
docs(SUPPORT): rewrite

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -33,10 +33,11 @@ find in our ports. For example, if you have an issue with the Catppuccin
 JetBrains theme, a GitHub issue should be raised on
 [catppuccin/jetbrains](https://github.com/catppuccin/jetbrains).
 
-We also highly recommended to provide extra details like your operating system,
-what version of the theme you installed, the configuration you applied, etc. Of
-course, these are not relevant to all ports but also understand some ports will
-require this information in order for an issue to be raised.
+We also highly recommend that you provide extra details like your operating
+system, what version of the theme you installed, the configuration you applied,
+~~was Mercury in retrograde when the issue occured?~~, etc. Of course, these are
+not relevant to all ports but also understand some ports will require this
+information in order for an issue to be raised.
 
 ### 3. Join the [Discord](https://discord.com/servers/catppuccin-907385605422448742)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -34,7 +34,7 @@ JetBrains theme, a GitHub issue should be raised on
 [catppuccin/jetbrains](https://github.com/catppuccin/jetbrains).
 
 We also highly recommended to provide extra details like your operating system,
-what version of the theme you installed, the configuration you applied etc. Of
+what version of the theme you installed, the configuration you applied, etc. Of
 course, these are not relevant to all ports but also understand some ports will
 require this information in order for an issue to be raised.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,15 +1,46 @@
-# 😍 Support for deploying and using Catppuccin!
+<div align="center">
+  <h2>🫶 Support</h2>
+  <p>Where to get help in case things don't work</p>
+</div>
 
-Welcome to Catppuccin! We use GitHub for tracking bugs and feature requests. This isn't the right place to get support for using Catppuccin, but the following resources are available below, thanks for understanding.
+Welcome to Catppuccin! We have many ports across the organisation contributed
+and maintained by people all over the world. However, issues and bug reports are
+never-ending due to how many we have!
 
-## Real-time Chat
+Ultimately, Catppuccin relies on open source contributions from the community to
+keep ports healthy and up-to-date. You may find that certain repositories
+contain outdated documentation, long-standing issues or stale pull requests. It
+is **always appreciated** if you are able to help debug an issue, provide extra
+context, contribute to another pull request, etc.
 
-- [Discord](https://discord.com/servers/catppuccin-907385605422448742): The Catppuccin Community is active on Discord, you can post your questions there.
+If you are encountering an issue with a port, follow the guidance listed below:
 
-## 📄 Documentation
+### 1. Read the README
 
-Under development.
+**Make sure you have read and followed the `README`**. Every port will have this
+file, explaining how to install the theme or modify the application to install
+Catppuccin. It is shown by default when you visit a GitHub repository.
 
-## 👥 Forum
+### 2. Raise a GitHub Issue
 
-Under development.
+**Raise a GitHub issue on the relevant port's repository**. If you have followed the
+`README` and are still having trouble applying Catppuccin, raise a GitHub issue
+clearly explaining what you have tried and what you expect to happen.
+
+Do not raise GitHub issues in
+[catppuccin/catppuccin](https://github.com/catppuccin/catppuccin) for bugs you
+find in our ports. For example, if you have an issue with the Catppuccin
+JetBrains theme, a GitHub issue should be raised on
+[catppuccin/jetbrains](https://github.com/catppuccin/jetbrains).
+
+We also highly recommended to provide extra details like your operating system,
+what version of the theme you installed, the configuration you applied etc. Of
+course, these are not relevant to all ports but also understand some ports will
+require this information in order for an issue to be raised.
+
+### 3. Join the [Discord](https://discord.com/servers/catppuccin-907385605422448742)
+
+**Join our Discord server!**. If you feel like your issue has gone stale or you
+don't feel comfortable raising a GitHub Issue, feel free to join our discord
+server! The Catppuccin community is active on Discord and you can post your
+questions in our dedicated `#support` channel.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -40,7 +40,7 @@ require this information in order for an issue to be raised.
 
 ### 3. Join the [Discord](https://discord.com/servers/catppuccin-907385605422448742)
 
-**Join our Discord server!**. If you feel like your issue has gone stale or you
+**Join our Discord server!** If you feel like your issue has gone stale or you
 don't feel comfortable raising a GitHub Issue, feel free to join our discord
 server! The Catppuccin community is active on Discord and you can post your
 questions in our dedicated `#support` channel.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -36,8 +36,8 @@ JetBrains theme, a GitHub issue should be raised on
 We also highly recommend that you provide extra details like your operating
 system, what version of the theme you installed, the configuration you applied,
 ~~was Mercury in retrograde when the issue occured?~~, etc. Of course, these are
-not relevant to all ports but also understand some ports will require this
-information in order for an issue to be raised.
+not relevant to all ports, but some ports will require this information in order
+for an issue to be raised and acted upon.
 
 ### 3. Join the [Discord](https://discord.com/servers/catppuccin-907385605422448742)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -48,6 +48,5 @@ questions in our dedicated `#support` channel.
 
 You can also ask for help and guidance on creating new ports to be transferred
 into the Catppuccin GitHub organisation. Often, this can streamline the process
-as the feedback loop is usually faster on Discord compared to GitHub, and more
-people will be exposed/interested to your work, even if it's a work in a
-progress!
+as the feedback loop is usually faster on Discord compared to GitHub and more
+people will be exposed to and/or interested in your work.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -42,6 +42,12 @@ information in order for an issue to be raised.
 ### 3. Join the [Discord](https://discord.com/servers/catppuccin-907385605422448742)
 
 **Join our Discord server!** If you feel like your issue has gone stale or you
-don't feel comfortable raising a GitHub Issue, feel free to join our discord
+don't feel comfortable raising a GitHub Issue, feel free to join our Discord
 server! The Catppuccin community is active on Discord and you can post your
 questions in our dedicated `#support` channel.
+
+You can also ask for help and guidance on creating new ports to be transferred
+into the Catppuccin GitHub organisation. Often, this can streamline the process
+as the feedback loop is usually faster on Discord compared to GitHub, and more
+people will be exposed/interested to your work, even if it's a work in a
+progress!


### PR DESCRIPTION

It's about time I got to working on this repository...

This PR rewrites the `SUPPORT.md` document to highlight 3 general ways that
users should get help for using Catppuccin. (Following the `README`, Raising a
GitHub issue and Joining the Discord)

It's by no means extensive but this document is in a nicer state than it was
before, and can easily be expanded on in the future.
