### PR TITLE
docs(rulesets): standardise repository rulesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ The purpose of this repository is to store default organisation wide [GitHub
 community health
 files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#supported-file-types),
 such as [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md),
-[SECURITY.md](./SECURITY.md), [FUNDING.yml](./FUNDING.yml), etc.
+[SECURITY.md](./SECURITY.md), [FUNDING.yml](./FUNDING.yml), etc. It is also a
+place to store files that need to be referenced multiple times across the
+organisation.
 
 &nbsp;
 

--- a/rulesets/README.md
+++ b/rulesets/README.md
@@ -35,9 +35,10 @@ unwanted commits being merged into the default branch.
 #### Automated Script
 
 The preferred method of applying these rulesets will be through a script making
-use of the [GraphQL `createRepositoryRuleset`
-Mutation](https://docs.github.com/en/graphql/reference/mutations#createrepositoryruleset),
-however, there are some considerations to keep in mind which are listed below:
+use of the GraphQL
+[`createRepositoryRuleset`](https://docs.github.com/en/graphql/reference/mutations#createrepositoryruleset)
+mutation, however, there are some considerations to keep in mind which are
+listed below:
 
 1. A non-zero amount of repositories already contain these rulesets, so the
    script needs to be robust in order to handle rulesets with the same name. Also,

--- a/rulesets/README.md
+++ b/rulesets/README.md
@@ -1,0 +1,69 @@
+<div align="center">
+  <h2>🛡️ GitHub Rulesets</h2>
+  <p>Increasing visibility of contributions across the organisation</p>
+</div>
+
+### What are rulesets?
+
+GitHub rulesets allow control over how people interact with Catppuccin's
+repositories, involving restrictions on deleting branches, force pushing the
+default branch, and much more. To learn more about what rulesets offer, see
+"[About rulesets - GitHub
+Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)."
+
+### What rulesets will Catppuccin apply?
+
+| Ruleset                                                    | Description                                                                                                  |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [Block Force Push](rulesets/block-force-push.json)         | Block any force push to the default branch.                                                                  |
+| [Require Pull Request](rulesets/require-pull-request.json) | Require a pull request to be created against the default branch.<br/>(Excluding organisation administrators) |
+
+### Why are these rulesets being applied?
+
+We want to **increase the visibility of contributions across the organisation**.
+The Catppuccin Discord server has `#github` channel which sends a message when a
+pull request is raised on any repository. Enforcing pull requests means that the
+visibility of the contribution is extended past just the people watching the
+repository, but also people in the active Discord community.
+
+Naturally, this results in more people looking at the pull request, giving
+helpful suggestions/opinions, and even reducing the chance of malicious or
+unwanted commits being merged into the default branch.
+
+### How will these rulesets be applied?
+
+#### Automated Script
+
+The preferred method of applying these rulesets will be through a script making
+use of the [GraphQL `createRepositoryRuleset`
+Mutation](https://docs.github.com/en/graphql/reference/mutations#createrepositoryruleset),
+however, there are some considerations to keep in mind which are listed below:
+
+1. A non-zero amount of repositories already contain these rulesets, so the
+   script needs to be robust in order to handle rulesets with the same name. Also,
+   the same rules may exist in a single ruleset or under different names so
+   existing rulesets should be vetted. I'd imagine the
+   [`updateRepositoryRuleset`](https://docs.github.com/en/graphql/reference/mutations#updaterepositoryruleset)
+   and
+   [`deleteRepositoryRuleset`](https://docs.github.com/en/graphql/reference/mutations#deleterepositoryruleset)
+   mutations will be needed here.
+2. Some repositories, such as
+   [catppuccin/jetbrains-icons](https://github.com/catppuccin/jetbrains-icons) and
+   [catppuccin/jetbrains](https://github.com/catppuccin/jetbrains), rely on the
+   ability to push directly to the default branch as part of their CI/CD release
+   workflows. These repositories need their CI/CD updated to use a `PAT` for the
+   cloning of the repository before the `Require Pull Request` ruleset can be
+   applied.
+
+The script (yet to be created) should account for the considerations listed
+above. In the meantime, the [Manual](#manual) instructions can be used to easily import
+the rulesets via the user interface.
+
+#### Manual
+
+1. Download the files located within the [rulesets/](rulesets) directory.
+2. Navigate to the GitHub repository you'd like to apply the rules on.
+3. Follow instructions outlined in "[Importing a ruleset - GitHub
+   Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/managing-rulesets-for-a-repository#importing-a-ruleset)"
+   to import your ruleset.
+4. Save your ruleset.

--- a/rulesets/README.md
+++ b/rulesets/README.md
@@ -11,7 +11,7 @@ default branch, and much more. To learn more about what rulesets offer, see
 "[About rulesets - GitHub
 Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)."
 
-### What rulesets will Catppuccin apply?
+### What rulesets will be applied?
 
 | Ruleset                                                    | Description                                                                                                  |
 | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |

--- a/rulesets/README.md
+++ b/rulesets/README.md
@@ -37,8 +37,7 @@ unwanted commits being merged into the default branch.
 The preferred method of applying these rulesets will be through a script making
 use of the GraphQL
 [`createRepositoryRuleset`](https://docs.github.com/en/graphql/reference/mutations#createrepositoryruleset)
-mutation, however, there are some considerations to keep in mind which are
-listed below:
+mutation, however, there are some considerations to keep in mind:
 
 1. A non-zero amount of repositories already contain these rulesets, so the
    script needs to be robust in order to handle rulesets with the same name. Also,

--- a/rulesets/rulesets/block-force-push.json
+++ b/rulesets/rulesets/block-force-push.json
@@ -1,0 +1,25 @@
+{
+  "id": 1783283,
+  "name": "Block Force Push",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "catppuccin/website",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/rulesets/rulesets/require-pull-request.json
+++ b/rulesets/rulesets/require-pull-request.json
@@ -1,0 +1,35 @@
+{
+  "id": 568296,
+  "name": "Require Pull Request",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "catppuccin/website",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION

This PR adds documentation on GitHub rulesets and how Catppuccin should take
advantage of them going forward. I have already been adding these rulesets here
and there for the past few months but the end goal was always to standardise it
and create an automated way of creating and updating rulesets across the
organisation.

The initial rulesets that I have been applying (blocking force push and
requiring PRs) is not the final list by any means. I imagine this will grow and
be modified as we move forward.

I'll leave this open for a few days for feedback.
